### PR TITLE
New function for the number of retrials / Daily reload of hooks

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1366,6 +1366,17 @@ class Worker
 	}
 
 	/**
+	 * Get the number of retrials for the current worker task
+	 *
+	 * @return integer
+	 */
+	public static function getRetrial(): int
+	{
+		$queue = DI::app()->getQueue();
+		return $queue['retrial'] ?? 0;
+	}
+
+	/**
 	 * Defers the current worker entry
 	 *
 	 * @return boolean had the entry been deferred?

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Worker;
 
+use Friendica\Core\Addon;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Core\Worker;
@@ -145,6 +146,8 @@ class Cron
 
 			// Update "blocked" status of servers
 			Worker::add(Worker::PRIORITY_LOW, 'UpdateBlockedServers');
+
+			Addon::reload();
 
 			DI::keyValue()->set('last_cron_daily', time());
 		}


### PR DESCRIPTION
This PR covers two different areas. 
- To make sure that all hooks are loaded, we now refresh the list of hooks once per day
- We've got a new function to return the number of retrials for the current worker task.