### PR TITLE
Store Pixelfed's capabilities

### DIFF
--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -60,6 +60,10 @@ class Tag
 	const AUDIENCE   = 14;
 	const ATTRIBUTED = 15;
 
+	const CAN_ANNOUNCE = 20;
+	const CAN_LIKE     = 21;
+	const CAN_REPLY    = 22;
+
 	const ACCOUNT             = 1;
 	const GENERAL_COLLECTION  = 2;
 	const FOLLOWER_COLLECTION = 3;

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1943,11 +1943,27 @@ class Receiver
 		$object_data['receiver']       = $receivers;
 		$object_data['reception_type'] = $reception_types;
 
+		if (!empty($object['pixelfed:capabilities'])) {
+			$object_data['capabilities'] = self::getCapabilities($object);
+		}
+
 		$object_data['unlisted'] = in_array(-1, $object_data['receiver']);
 		unset($object_data['receiver'][-1]);
 		unset($object_data['reception_type'][-1]);
 
 		return $object_data;
+	}
+
+	private static function getCapabilities($object) {
+		$capabilities = [];
+		foreach (['pixelfed:canAnnounce', 'pixelfed:canLike', 'pixelfed:canReply'] as $element) {
+			$capabilities_list = JsonLD::fetchElementArray($object['pixelfed:capabilities'], $element, '@id');
+			if (empty($capabilities_list)) {
+				continue;
+			}
+			$capabilities[$element] = $capabilities_list;
+		}
+		return $capabilities;
 	}
 
 	/**

--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -171,6 +171,7 @@ class JsonLD
 			'mobilizon' => (object)['@id' => 'https://joinmobilizon.org/ns#', '@type' => '@id'],
 			'fedibird' => (object)['@id' => 'http://fedibird.com/ns#', '@type' => '@id'],
 			'misskey' => (object)['@id' => 'https://misskey-hub.net/ns#', '@type' => '@id'],
+			'pixelfed' => (object)['@id' => 'http://pixelfed.org/ns#', '@type' => '@id'],
 		];
 
 		$orig_json = $json;


### PR DESCRIPTION
Pixelfed supports "capabilities" which defines, if you can reply, reshare or like a post. We now store this data, although we don't process it in the moment.