### PR TITLE
Normalize API fixture data

### DIFF
--- a/tests/datasets/api.fixture.php
+++ b/tests/datasets/api.fixture.php
@@ -215,7 +215,7 @@ return [
 			'id'       => 48,
 			'uid'      => 0,
 			'uri-id'   => 42,
-			'name'     => 'Self contact',
+			'name'     => 'Test user',
 			'nick'     => 'selfcontact',
 			'self'     => 0,
 			'nurl'     => 'http://friendica.local/profile/selfcontact',
@@ -928,6 +928,7 @@ return [
 		[
 			'id'  => 1,
 			'uid' => 42,
+			'locality' => 'DFRN',
 		],
 	],
 	'group' => [

--- a/tests/src/Module/Api/ApiTest.php
+++ b/tests/src/Module/Api/ApiTest.php
@@ -43,7 +43,7 @@ abstract class ApiTest extends FixtureTest
 	// User data that the test database is populated with
 	const SELF_USER = [
 		'id'   => 42,
-		'name' => 'Self contact',
+		'name' => 'Test user',
 		'nick' => 'selfcontact',
 		'nurl' => 'http://localhost/profile/selfcontact'
 	];


### PR DESCRIPTION
- Change public contact name to the related local user name
- Add location data to profile record that is used to update self and public contact during Auth